### PR TITLE
Update numpy version

### DIFF
--- a/streamlit_app/requirements.txt
+++ b/streamlit_app/requirements.txt
@@ -1,3 +1,4 @@
 boto3==1.26.73
 pandas==1.5.3
 streamlit==1.20.0
+numpy==1.26.4


### PR DESCRIPTION
Need this version of numpy else "streamlit_app/sh run.sh" throws errors and does not give a port number.